### PR TITLE
Fix bedtools over zealous exit

### DIFF
--- a/repeat-soaker
+++ b/repeat-soaker
@@ -38,8 +38,8 @@ input_bam="$1"
 }
 [[ -z "$repeat_regions" ]] && usage && exit 1
 
-((command -v bedtools >/dev/null) || echo "bedtools not found in \$PATH" && exit 1)
-((command -v samtools >/dev/null) || echo "samtools not found in \$PATH" && exit 1)
+((command -v bedtools >/dev/null) || (echo "bedtools not found in \$PATH" ; exit 1))
+((command -v samtools >/dev/null) || (echo "samtools not found in \$PATH" ; exit 1))
 
 # Filters out (-v) coordinate-sorted BAM file overlapping $repeat_regions file
 # at least $percent_overlap (-f). Output into $output_bam BAM file


### PR DESCRIPTION
Missing some extra parens to keep the silly check for the bedtools/samtools from always going off & exit 1ing
